### PR TITLE
Fix the warning:  ReactNative.createElement is deprecated.

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,4 +1,4 @@
-import React, { AppRegistry } from 'react-native';
+import { AppRegistry } from 'react-native';
 import App from './src/App';
 
 AppRegistry.registerComponent('ReactNativeWeather', () => App);

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,4 +1,4 @@
-import React, { AppRegistry } from 'react-native';
+import { AppRegistry } from 'react-native';
 import App from './src/App';
 
 AppRegistry.registerComponent('ReactNativeWeather', () => App);

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import React, { Component } from 'react-native';
+import React, { Component } from 'react';
 import WeatherView from './components/WeatherView';
 
 class ReactNativeWeather extends Component {

--- a/src/components/ForecastView.js
+++ b/src/components/ForecastView.js
@@ -1,7 +1,7 @@
 'use strict'
 
-import React, {
-  Component,
+import React, { Component } from 'react';
+import {
   Text,
   View
 } from 'react-native';

--- a/src/components/WeatherView.js
+++ b/src/components/WeatherView.js
@@ -1,7 +1,7 @@
 'use strict'
 
-import React, {
-  Component,
+import React, { Component } from 'react';
+import {
   StyleSheet,
   ActivityIndicatorIOS,
   Text,


### PR DESCRIPTION
Fix the warning:  ReactNative.createElement is deprecated. Use React.createElement from the "react" package instead

Should close #8 thanks to @philip13 
